### PR TITLE
#169537425 Fix bug articles created redirect 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
     "react/no-unescaped-entities": 0,
     "react/prop-types": 0,
     "no-shadow": 0,
-    "consistent-return": 0
+    "consistent-return": 0,
+    "react/require-default-props": 0
   }
 }

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -41,7 +41,14 @@ const Routes = () => (
     <Route exact path="/welcome" component={Welcome} />
     <Route exact path="/search" component={Search} />
     <Route exact path="/login" component={Login} />
-    <Route exact path="/articles/create" component={CreateArticles} />
+    <Route
+      exact
+      path="/articles/create"
+      render={(props) => {
+        if (!user) return <Redirect to="/login" />;
+        return <CreateArticles {...props} />;
+      }}
+    />
     <Route exact path="/articles/mine" component={SpecificUserArticles} />
     <Route exact path="/privacy" component={Privacy} />
     <Route exact path="/article/:slug" component={ViewArticle} />

--- a/src/components/articles/createArticles/createArticles.js
+++ b/src/components/articles/createArticles/createArticles.js
@@ -32,8 +32,9 @@ export class CreateArticles extends React.Component {
       title: '',
       body: '',
       description: '',
-      schem: '',
+      schema: '',
       images: [],
+      isArticleCreated: false,
       imageWidget: cloudinary.createUploadWidget(
         {
           cloudName: 'nshuti-jonathan',
@@ -58,13 +59,14 @@ export class CreateArticles extends React.Component {
   }
 
   componentWillReceiveProps = (nextProps) => {
-    const { createdArticleData } = nextProps;
-
+    const { createdArticleData, history } = nextProps;
+    const isArticleCreated = createdArticleData;
     if (createdArticleData && Array.isArray(createdArticleData.err)) {
       createdArticleData.err.forEach(({ message }) => {
         toast.error(message);
       });
     }
+    return isArticleCreated ? history.push('/profile') : '';
   };
 
   handleChange = (html) => {
@@ -90,7 +92,7 @@ export class CreateArticles extends React.Component {
   render() {
     const { title, body, description } = this.state;
     return (
-      <div className="col-12 col-lg-6 offset-lg-3">
+      <div className="col-12 col-lg-6 offset-lg-3 create-div">
         <h3>Create Article</h3>
         <div className="form-group">
           <label>Article Title</label>
@@ -136,9 +138,10 @@ export class CreateArticles extends React.Component {
           required
         />
         <ToastContainer />
+
         <button
           onClick={this.handleSubmit}
-          className="btn btn-primary float-right"
+          className="btn btn-primary float-right publish-button"
           type="button"
         >
           Publish
@@ -151,7 +154,7 @@ export const mapStateToProps = ({ createdArticleData }) => ({
   createdArticleData,
 });
 CreateArticles.propTypes = {
-  createArticlesAction: PropTypes.isRequired,
+  createArticlesAction: PropTypes.func,
 };
 export default connect(
   mapStateToProps,

--- a/src/components/articles/createArticles/createArticles.scss
+++ b/src/components/articles/createArticles/createArticles.scss
@@ -17,3 +17,9 @@
   display: block;
   overflow: auto;
 }
+.publish-button {
+  margin-top: 20px;
+}
+.create-div {
+  margin-bottom: 200px;
+}


### PR DESCRIPTION

#### What does this PR do?
- Added a redirect page on articles created successfully
#### Description of Task to be completed?
- When a user successfully publish an article he must be redirected to the profile page
- Added security measures, only authenticated user can access `articles/create ` route
- Fixed the publish button, now on Heroku User can see the publish button,initially, we had not it fixed 
#### How should this be manually tested?
Download or clone the tutorial project code from this [repo,](https://github.com/andela/codepirates-ah-frontend) in your terminal then git checkout ` bg-fix-redirect-on-articles-created-169537425`, install all required NPM packages by running ` npm install ` from the command line in the project root folder (where the package.json is located) then after in localhost visit /articles create page
#### Any background context you want to provide?
- I added some css to make publish button more visible
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/169594283
#### Screenshots (if appropriate)

#### Questions:
